### PR TITLE
Return bytes for null and boolean in the encoder, not str

### DIFF
--- a/pyhessian/encoder.py
+++ b/pyhessian/encoder.py
@@ -136,14 +136,14 @@ class Encoder(object):
 
     @encoder_for(type(None))
     def encode_null(self, _):
-        return 'N'
+        return b'N'
 
     @encoder_for(bool)
     def encode_boolean(self, value):
         if value:
-            return 'T'
+            return b'T'
         else:
-            return 'F'
+            return b'F'
 
     @encoder_for(int)
     def encode_int(self, value):
@@ -317,8 +317,6 @@ class Encoder(object):
             data_type, arg = self.encode_arg(arg)
             if call.overload:
                 method += b'_' + six.b(data_type)
-            if isinstance(arg, six.text_type):
-                arg = six.b(arg)
             arguments += arg
 
         encoded = pack('>cBB', b'c', call.version, 0)


### PR DESCRIPTION
The tests hadn't caught this issue because we had a hack in `encode_call()` that would force the encoder return values to be `bytes` if they were `str`. In the test suite, we only ever check encoding of objects passed as arguments to a call. But in cases where the boolean or null values were not arguments to a call (e.g. if they were part of a nested data structure) the encoding would fail with the error "Can't concat str to bytes".

These types now encode properly and the hack has been removed.