### PR TITLE
Add ability to select SSL context for httplib.HTTPSConnection

### DIFF
--- a/pyhessian/client.py
+++ b/pyhessian/client.py
@@ -34,7 +34,8 @@ class HessianProxy(object):
 
     def __init__(self, service_uri, credentials=None, key_file=None,
             cert_file=None, timeout=10, buffer_size=65535,
-            error_factory=identity_func, overload=False, version=1):
+            error_factory=identity_func, overload=False, version=1,
+            context=None):
         self.version = version
         self.timeout = timeout
         self._buffer_size = buffer_size
@@ -42,6 +43,7 @@ class HessianProxy(object):
         self._overload = overload
         self.key_file = key_file
         self.cert_file = cert_file
+        self.context = context
         self._uri = urlparse(service_uri)
 
         if self._uri.scheme not in ('http', 'https'):
@@ -73,6 +75,7 @@ class HessianProxy(object):
             kwargs.update({
                 'key_file': self.key_file,
                 'cert_file': self.cert_file,
+                'context': self.context,
             })
         else:
             connection_cls = HTTPConnection

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ class Tox(TestCommand):
 
 setup(
     name="python-hessian",
-    version='1.1.2',
+    version='1.2.0',
     description="Hessian RPC Library",
     long_description=open(
         os.path.join(os.path.dirname(__file__), 'README.rst')).read(),


### PR DESCRIPTION
Since [python 3.6](https://docs.python.org/3/library/http.client.html#http.client.HTTPSConnection), the keyword arguments `key_file` and `cert_file` have been deprecated in favor of using `context`, which is an object retrieved via the `ssl` module.

I have added the `context` keyword argument to the `HessianProxy` constructor, which is then passed to `HTTPSConnection` in the same way that `key_file` and `cert_file` are.